### PR TITLE
Fix and improvement (sort, selection)

### DIFF
--- a/.checkstyle
+++ b/.checkstyle
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<fileset-config file-format-version="1.2.0" simple-config="true" sync-formatter="false">
+  <local-check-config name="JOSM" location="/JOSM/tools/checkstyle/josm_checks.xml" type="project" description="">
+    <additional-data name="protect-config-file" value="false"/>
+  </local-check-config>
+  <fileset name="all" enabled="true" check-config-name="JOSM" local="true">
+    <file-match-pattern match-pattern="." include-pattern="true"/>
+  </fileset>
+  <filter name="DerivedFiles" enabled="true"/>
+  <filter name="FilesFromPackage" enabled="true">
+    <filter-data value="src/com"/>
+    <filter-data value="data"/>
+    <filter-data value="images"/>
+    <filter-data value="nbproject"/>
+  </filter>
+</fileset-config>

--- a/.project
+++ b/.project
@@ -15,8 +15,14 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>net.sf.eclipsecs.core.CheckstyleBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
 		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>net.sf.eclipsecs.core.CheckstyleNature</nature>
 	</natures>
 </projectDescription>

--- a/src/org/openstreetmap/josm/plugins/conflation/ConflateMatchCommand.java
+++ b/src/org/openstreetmap/josm/plugins/conflation/ConflateMatchCommand.java
@@ -1,11 +1,17 @@
-// License: GPL. See LICENSE file for details. Copyright 2012 by Josh Doe and others.
+// License: GPL. For details, see LICENSE file.
+// Copyright 2012 by Josh Doe and others.
 package org.openstreetmap.josm.plugins.conflation;
 
-import java.util.ArrayList;
+import static org.openstreetmap.josm.tools.I18n.tr;
+
+import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.stream.Collectors;
+
 import javax.swing.Icon;
+
 import org.openstreetmap.josm.command.AddPrimitivesCommand;
 import org.openstreetmap.josm.command.Command;
 import org.openstreetmap.josm.command.PseudoCommand;
@@ -13,17 +19,20 @@ import org.openstreetmap.josm.data.osm.DataSet;
 import org.openstreetmap.josm.data.osm.OsmPrimitive;
 import org.openstreetmap.josm.data.osm.PrimitiveData;
 import org.openstreetmap.josm.plugins.utilsplugin2.replacegeometry.ReplaceGeometryUtils;
-import static org.openstreetmap.josm.tools.I18n.tr;
 import org.openstreetmap.josm.tools.ImageProvider;
 import org.openstreetmap.josm.tools.UserCancelException;
+
 
 /**
  * Command to conflate one object with another.
  */
 public class ConflateMatchCommand extends Command {
+
+    private final DataSet sourceDataSet;
+    private final DataSet targetDataSet;
     private final SimpleMatch match;
     private final SimpleMatchList matches;
-    private final Command replaceCommand;
+    private Command replaceCommand = null;
     private AddPrimitivesCommand addPrimitivesCommand = null;
 
     public ConflateMatchCommand(SimpleMatch match,
@@ -31,53 +40,69 @@ public class ConflateMatchCommand extends Command {
         super(settings.getSubjectLayer());
         this.match = match;
         this.matches = matches;
-        
-        DataSet sourceDataSet = settings.getReferenceDataSet();
-        DataSet targetDataSet = settings.getSubjectDataSet();
-        // copy objects from reference dataset
-        if (targetDataSet != sourceDataSet) {
-            // TODO: use MergeCommand instead?
-            List<PrimitiveData> newObjects = ConflationUtils.copyObjects(sourceDataSet, match.getReferenceObject());
-
-            // FIXME: bad form to execute command in constructor, how to fix?
-            addPrimitivesCommand = new AddPrimitivesCommand(newObjects, newObjects, settings.getSubjectLayer());
-            if (!addPrimitivesCommand.executeCommand())
-                throw new AssertionError();
-        }
-
-        // need to copy from other layer before this?
-        replaceCommand = ReplaceGeometryUtils.buildReplaceCommand(
-                            match.getSubjectObject(),
-                            targetDataSet.getPrimitiveById(match.getReferenceObject().getPrimitiveId()));
-
-        if (addPrimitivesCommand != null)
-            addPrimitivesCommand.undoCommand();
-        if (replaceCommand == null) {
-            throw new UserCancelException();
-        }
+        this.sourceDataSet = settings.getReferenceDataSet();
+        this.targetDataSet = settings.getSubjectDataSet();
+        // REM: in the previous version of this class, the sub commands 
+        // (AddPrimitiveCommand and ReplaceGeometryUtils.buildReplaceCommand)
+        // where builded in this constructor, now they are only builded in executeCommand(),
+        // so some exceptions that where thrown at construction will now only be be thrown at execution. 
     }
 
     @Override
     public boolean executeCommand() {
-        if (addPrimitivesCommand != null) {
-            if (!addPrimitivesCommand.executeCommand())
-                return false;
+        boolean ok = true;
+        try {
+            if (targetDataSet != sourceDataSet) {
+                if (addPrimitivesCommand == null) {
+                    List<PrimitiveData> newObjects = ConflationUtils.copyObjects(sourceDataSet, match.getReferenceObject());
+                    addPrimitivesCommand = new AddPrimitivesCommand(newObjects, newObjects, getLayer());
+                }
+                if (!addPrimitivesCommand.executeCommand()) {
+                    ok = false;
+                    addPrimitivesCommand = null;
+                }
+            }
+            if (ok) {
+                if (replaceCommand == null) {
+                    replaceCommand = ReplaceGeometryUtils.buildReplaceCommand(
+                                        match.getSubjectObject(),
+                                        targetDataSet.getPrimitiveById(match.getReferenceObject().getPrimitiveId()));
+                    if (replaceCommand == null) {
+                        throw new UserCancelRuntimeException();
+                    }
+                }
+                if (replaceCommand.executeCommand()) {
+                    matches.remove(match);
+                } else {
+                    ok = false;
+                }
+            }
+        } catch (RuntimeException e) {
+            ok = false;
+            throw e;
+        } finally {
+            if (!ok) {
+                replaceCommand = null;
+                if (addPrimitivesCommand != null) {
+                    addPrimitivesCommand.undoCommand();
+                    addPrimitivesCommand = null;
+                }
+            }
         }
-        if (!replaceCommand.executeCommand())
-            return false;
-        matches.remove(match);
-
-        return true;
+        return ok;
     }
-    
+
     @Override
     public void undoCommand() {
-        replaceCommand.undoCommand();
-        if (addPrimitivesCommand != null)
+        if (replaceCommand != null) {
+            replaceCommand.undoCommand();
+            matches.add(match);
+        }
+        if (addPrimitivesCommand != null) {
             addPrimitivesCommand.undoCommand();
-        matches.add(match);
+        }
     }
-    
+
     @Override
     public void fillModifiedData(Collection<OsmPrimitive> modified, Collection<OsmPrimitive> deleted, Collection<OsmPrimitive> added) {
         throw new UnsupportedOperationException("Not supported yet.");
@@ -88,26 +113,26 @@ public class ConflateMatchCommand extends Command {
         //TODO: make more descriptive
         return tr("Conflate object pair");
     }
-    
+
     @Override
     public Icon getDescriptionIcon() {
         return ImageProvider.get("dialogs", "conflation");
     }
-    
+
     @Override
     public Collection<? extends OsmPrimitive> getParticipatingPrimitives() {
-        return Collections.singleton(match.getSubjectObject());
+        Collection<OsmPrimitive> prims = new HashSet<>();
+        if (addPrimitivesCommand != null)
+            prims.addAll(addPrimitivesCommand.getParticipatingPrimitives());
+        if (replaceCommand != null)
+            prims.addAll(replaceCommand.getParticipatingPrimitives());
+        return prims;
     }
-    
+
     @Override
     public Collection<PseudoCommand> getChildren() {
-        if (replaceCommand == null)
-            return null;
-
-        Collection<PseudoCommand> children = new ArrayList<>();
-        if (addPrimitivesCommand != null)
-            children.add(addPrimitivesCommand);
-        children.addAll(replaceCommand.getChildren());
-        return children;
+        return Arrays.asList(addPrimitivesCommand, replaceCommand).stream()
+            .filter(c -> c != null)
+            .collect(Collectors.toList());
     }
 }

--- a/src/org/openstreetmap/josm/plugins/conflation/ConflateUnmatchedObjectCommand.java
+++ b/src/org/openstreetmap/josm/plugins/conflation/ConflateUnmatchedObjectCommand.java
@@ -1,7 +1,8 @@
-// License: GPL. See LICENSE file for details. Copyright 2012 by Josh Doe and others.
+// License: GPL. For details, see LICENSE file.
+// Copyright 2012 by Josh Doe and others.
 package org.openstreetmap.josm.plugins.conflation;
 
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import javax.swing.Icon;
@@ -69,11 +70,8 @@ public class ConflateUnmatchedObjectCommand extends Command {
         return unmatchedObjects;
     }
 
-
     @Override
     public Collection<PseudoCommand> getChildren() {
-        Collection<PseudoCommand> children = new ArrayList<>();
-        children.add(addPrimitivesCommand);
-        return children;
+        return Arrays.asList(addPrimitivesCommand);
     }
 }

--- a/src/org/openstreetmap/josm/plugins/conflation/ConflationLayer.java
+++ b/src/org/openstreetmap/josm/plugins/conflation/ConflationLayer.java
@@ -1,4 +1,5 @@
-// License: GPL. See LICENSE file for details. Copyright 2012 by Josh Doe and others.
+// License: GPL. For details, see LICENSE file.
+// Copyright 2012 by Josh Doe and others.
 package org.openstreetmap.josm.plugins.conflation;
 
 import static org.openstreetmap.josm.tools.I18n.tr;
@@ -31,12 +32,12 @@ import org.openstreetmap.josm.tools.ImageProvider;
  */
 public class ConflationLayer extends Layer {
     protected SimpleMatchList matches;
-    
+
     public ConflationLayer(SimpleMatchList matches) {
         super(tr("Conflation"));
         this.matches = matches;
     }
-    
+
     public ConflationLayer() {
         this(null);
     }
@@ -88,11 +89,8 @@ public class ConflationLayer extends Layer {
                 g2.draw(path);
             }
         }
-
-        
     }
 
-    
     @Override
     public Icon getIcon() {
         // TODO: change icon
@@ -121,9 +119,9 @@ public class ConflationLayer extends Layer {
             OsmPrimitive reference = match.getReferenceObject();
             OsmPrimitive subject = match.getSubjectObject();
             if (reference != null && reference instanceof Node)
-                v.visit((Node)reference);
+                v.visit((Node) reference);
             if (subject != null && subject instanceof Node)
-                v.visit((Node)subject);
+                v.visit((Node) subject);
         }
     }
 
@@ -142,7 +140,7 @@ public class ConflationLayer extends Layer {
                     SeparatorLayerAction.INSTANCE,
                     new LayerListPopup.InfoAction(this)};
     }
-    
+
     public void setMatches(SimpleMatchList matches) {
         this.matches = matches;
         // TODO: does repaint automatically occur?

--- a/src/org/openstreetmap/josm/plugins/conflation/ConflationPlugin.java
+++ b/src/org/openstreetmap/josm/plugins/conflation/ConflationPlugin.java
@@ -1,15 +1,12 @@
-// License: GPL. See LICENSE file for details. Copyright 2012 by Josh Doe and others.
+// License: GPL. For details, see LICENSE file.
+// Copyright 2012 by Josh Doe and others.
 package org.openstreetmap.josm.plugins.conflation;
-
-import java.awt.GraphicsEnvironment;
 
 import org.openstreetmap.josm.gui.MapFrame;
 import org.openstreetmap.josm.plugins.Plugin;
 import org.openstreetmap.josm.plugins.PluginInformation;
 
 public class ConflationPlugin extends Plugin {
-
-    private ConflationToggleDialog dialog = null;
 
     /**
      * constructor
@@ -21,11 +18,8 @@ public class ConflationPlugin extends Plugin {
     // add dialog the first time the mapframe is loaded
     @Override
     public void mapFrameInitialized(MapFrame oldFrame, MapFrame newFrame) {
-        if (oldFrame == null && newFrame != null && !GraphicsEnvironment.isHeadless()) {
-            if (dialog == null) {
-                dialog = new ConflationToggleDialog(this);
-            }
-            newFrame.addToggleDialog(dialog);
+        if (oldFrame == null && newFrame != null) {
+            newFrame.addToggleDialog(new ConflationToggleDialog(this));
         }
     }
 }

--- a/src/org/openstreetmap/josm/plugins/conflation/ConflationUtils.java
+++ b/src/org/openstreetmap/josm/plugins/conflation/ConflationUtils.java
@@ -1,10 +1,12 @@
-// License: GPL. See LICENSE file for details. Copyright 2012 by Josh Doe and others.
+// License: GPL. For details, see LICENSE file.
+// Copyright 2012 by Josh Doe and others.
 package org.openstreetmap.josm.plugins.conflation;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
+
 import org.openstreetmap.josm.Main;
 import org.openstreetmap.josm.data.coor.EastNorth;
 import org.openstreetmap.josm.data.coor.LatLon;
@@ -14,6 +16,8 @@ import org.openstreetmap.josm.data.osm.PrimitiveData;
 import org.openstreetmap.josm.data.osm.visitor.MergeSourceBuildingVisitor;
 
 public final class ConflationUtils {
+
+    private ConflationUtils() {}
 
     public static EastNorth getCenter(OsmPrimitive prim) {
         LatLon center = prim.getBBox().getTopLeft().getCenter(prim.getBBox().getBottomRight());
@@ -34,10 +38,8 @@ public final class ConflationUtils {
         //restore selection
         sourceDataSet.setSelected(origSelection);
 
-        List<PrimitiveData> newObjects = new ArrayList<>();
-        for (OsmPrimitive p : newDataSet.allPrimitives()) {
-            newObjects.add(p.save());
-        }
-        return newObjects;
+        return newDataSet.allPrimitives().stream()
+                .map(p -> p.save())
+                .collect(Collectors.toList());
     }
 }

--- a/src/org/openstreetmap/josm/plugins/conflation/MatchFinderPanel.java
+++ b/src/org/openstreetmap/josm/plugins/conflation/MatchFinderPanel.java
@@ -1,3 +1,4 @@
+// License: GPL. For details, see LICENSE file.
 package org.openstreetmap.josm.plugins.conflation;
 
 import static org.openstreetmap.josm.tools.I18n.tr;
@@ -26,7 +27,6 @@ import com.vividsolutions.jcs.conflate.polygonmatch.HausdorffDistanceMatcher;
 import com.vividsolutions.jcs.conflate.polygonmatch.IdenticalFeatureFilter;
 import com.vividsolutions.jcs.conflate.polygonmatch.OneToOneFCMatchFinder;
 
-
 public class MatchFinderPanel extends JPanel {
     private final JComboBox<String> matchFinderComboBox;
     private final CentroidDistanceComponent centroidDistanceComponent;
@@ -35,7 +35,7 @@ public class MatchFinderPanel extends JPanel {
         setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
         setBorder(new CompoundBorder(
                 BorderFactory.createTitledBorder(tr("Match finder settings")),
-                BorderFactory.createEmptyBorder(5,5,5,5)));
+                BorderFactory.createEmptyBorder(5, 5, 5, 5)));
 
         String[] matchFinderStrings = {"DisambiguatingFCMatchFinder", "OneToOneFCMatchFinder" };
         matchFinderComboBox = new JComboBox<>(matchFinderStrings);
@@ -72,10 +72,10 @@ public class MatchFinderPanel extends JPanel {
     abstract class DistanceComponent extends AbstractScoreComponent {
         SpinnerNumberModel threshDistanceSpinnerModel;
 
-        public DistanceComponent(String title) {
+        DistanceComponent(String title) {
             setBorder(new CompoundBorder(
                     BorderFactory.createTitledBorder(tr(title)),
-                    BorderFactory.createEmptyBorder(5,5,5,5)));
+                    BorderFactory.createEmptyBorder(5, 5, 5, 5)));
 
             JPanel panel = new JPanel();
             panel.setLayout(new BoxLayout(panel, BoxLayout.LINE_AXIS));
@@ -99,7 +99,7 @@ public class MatchFinderPanel extends JPanel {
     }
 
     class CentroidDistanceComponent extends DistanceComponent {
-        public CentroidDistanceComponent() {
+        CentroidDistanceComponent() {
             super(tr("Centroid distance"));
         }
 
@@ -112,7 +112,7 @@ public class MatchFinderPanel extends JPanel {
     }
 
     class HausdorffDistanceComponent extends DistanceComponent {
-        public HausdorffDistanceComponent() {
+        HausdorffDistanceComponent() {
             super(tr("Hausdorff distance"));
         }
 

--- a/src/org/openstreetmap/josm/plugins/conflation/OsmFeature.java
+++ b/src/org/openstreetmap/josm/plugins/conflation/OsmFeature.java
@@ -1,4 +1,5 @@
-// License: GPL. See LICENSE file for details. Copyright 2012 by Josh Doe and others.
+// License: GPL. For details, see LICENSE file.
+// Copyright 2012 by Josh Doe and others.
 package org.openstreetmap.josm.plugins.conflation;
 
 import com.vividsolutions.jump.feature.AbstractBasicFeature;
@@ -16,7 +17,6 @@ public class OsmFeature extends AbstractBasicFeature {
     /**
      * Create a copy of the OSM geometry
      * TODO: update from underlying primitive
-     * @param prim 
      */
     public OsmFeature(OsmPrimitive prim, JTSConverter jtsConverter) {
         super(new FeatureSchema());

--- a/src/org/openstreetmap/josm/plugins/conflation/SettingsDialog.java
+++ b/src/org/openstreetmap/josm/plugins/conflation/SettingsDialog.java
@@ -1,4 +1,5 @@
-// License: GPL. See LICENSE file for details. Copyright 2012 by Josh Doe and others.
+// License: GPL. For details, see LICENSE file.
+// Copyright 2012 by Josh Doe and others.
 package org.openstreetmap.josm.plugins.conflation;
 
 import static org.openstreetmap.josm.tools.I18n.tr;
@@ -26,7 +27,9 @@ import org.openstreetmap.josm.data.osm.OsmPrimitive;
 import org.openstreetmap.josm.data.osm.Relation;
 import org.openstreetmap.josm.data.osm.Way;
 import org.openstreetmap.josm.gui.ExtendedDialog;
+import org.openstreetmap.josm.gui.layer.Layer;
 import org.openstreetmap.josm.gui.layer.OsmDataLayer;
+import org.openstreetmap.josm.gui.layer.LayerManager.LayerRemoveEvent;
 import org.openstreetmap.josm.tools.ImageProvider;
 
 /**
@@ -92,7 +95,7 @@ public class SettingsDialog extends ExtendedDialog {
 
         referencePanel.setBorder(new CompoundBorder(
                 BorderFactory.createTitledBorder(tr("Reference")),
-                BorderFactory.createEmptyBorder(5,5,5,5)));
+                BorderFactory.createEmptyBorder(5, 5, 5, 5)));
         referencePanel.setAlignmentX(LEFT_ALIGNMENT);
         referencePanel.setLayout(new BoxLayout(referencePanel,
                 BoxLayout.PAGE_AXIS));
@@ -129,7 +132,7 @@ public class SettingsDialog extends ExtendedDialog {
 
         subjectPanel.setBorder(new CompoundBorder(
                 BorderFactory.createTitledBorder(tr("Subject")),
-                BorderFactory.createEmptyBorder(5,5,5,5)));
+                BorderFactory.createEmptyBorder(5, 5, 5, 5)));
         subjectPanel.setAlignmentX(LEFT_ALIGNMENT);
         subjectPanel.setLayout(new BoxLayout(subjectPanel, BoxLayout.PAGE_AXIS));
 
@@ -172,16 +175,15 @@ public class SettingsDialog extends ExtendedDialog {
 
     /**
      * Matches are actually generated in windowClosed event in ConflationToggleDialog
-     *
-     * @param buttonIndex
-     * @param evt
      */
     @Override
     protected void buttonAction(int buttonIndex, ActionEvent evt) {
         // "Generate matches" as clicked
         if (buttonIndex == 0) {
             if (referenceSelection.isEmpty() || subjectSelection.isEmpty()) {
-                JOptionPane.showMessageDialog(Main.parent, tr("Selections must be made for both reference and subject."), tr("Incomplete selections"), JOptionPane.ERROR_MESSAGE);
+                JOptionPane.showMessageDialog(Main.parent,
+                        tr("Selections must be made for both reference and subject."), tr("Incomplete selections"),
+                        JOptionPane.ERROR_MESSAGE);
                 return;
             }
         }
@@ -220,7 +222,7 @@ public class SettingsDialog extends ExtendedDialog {
 
     class RestoreSubjectAction extends JosmAction {
 
-        public RestoreSubjectAction() {
+        RestoreSubjectAction() {
             super(tr("Restore"), null, tr("Restore subject selection"), null, false);
         }
 
@@ -236,7 +238,7 @@ public class SettingsDialog extends ExtendedDialog {
 
     class RestoreReferenceAction extends JosmAction {
 
-        public RestoreReferenceAction() {
+        RestoreReferenceAction() {
             super(tr("Restore"), null, tr("Restore reference selection"), null, false);
         }
 
@@ -252,28 +254,26 @@ public class SettingsDialog extends ExtendedDialog {
 
     class FreezeSubjectAction extends JosmAction {
 
-        public FreezeSubjectAction() {
+        FreezeSubjectAction() {
             super(tr("Freeze"), null, tr("Freeze subject selection"), null, false);
         }
 
         @Override
         public void actionPerformed(ActionEvent e) {
-            if (subjectDataSet != null && subjectDataSet == Main.getLayerManager().getEditDataSet()) {
-                //                subjectDataSet.removeDataSetListener(this); FIXME:
-                //                subjectDataSet.removeDataSetListener(this); FIXME:
-            }
             subjectDataSet = Main.getLayerManager().getEditDataSet();
-            //            subjectDataSet.addDataSetListener(tableModel); FIXME:
-            //            subjectDataSet.addDataSetListener(tableModel); FIXME:
             subjectLayer = Main.getLayerManager().getEditLayer();
             if (subjectDataSet == null || subjectLayer == null) {
-                JOptionPane.showMessageDialog(Main.parent, tr("No valid OSM data layer present."), tr("Error freezing selection"), JOptionPane.ERROR_MESSAGE);
+                JOptionPane.showMessageDialog(Main.parent,
+                    tr("No valid OSM data layer present."), tr("Error freezing selection"),
+                    JOptionPane.ERROR_MESSAGE);
                 return;
             }
             subjectSelection.clear();
             subjectSelection.addAll(subjectDataSet.getSelected());
             if (subjectSelection.isEmpty()) {
-                JOptionPane.showMessageDialog(Main.parent, tr("Nothing is selected, please try again."), tr("Empty selection"), JOptionPane.ERROR_MESSAGE);
+                JOptionPane.showMessageDialog(Main.parent,
+                        tr("Nothing is selected, please try again."), tr("Empty selection"),
+                        JOptionPane.ERROR_MESSAGE);
                 return;
             }
             update();
@@ -282,28 +282,26 @@ public class SettingsDialog extends ExtendedDialog {
 
     class FreezeReferenceAction extends JosmAction {
 
-        public FreezeReferenceAction() {
+        FreezeReferenceAction() {
             super(tr("Freeze"), null, tr("Freeze reference selection"), null, false);
         }
 
         @Override
         public void actionPerformed(ActionEvent e) {
-            if (referenceDataSet != null && referenceDataSet == Main.getLayerManager().getEditDataSet()) {
-                //                referenceDataSet.removeDataSetListener(this); FIXME:
-                //                referenceDataSet.removeDataSetListener(this); FIXME:
-            }
             referenceDataSet = Main.getLayerManager().getEditDataSet();
-            //            referenceDataSet.addDataSetListener(this); FIXME:
-            //            referenceDataSet.addDataSetListener(this); FIXME:
             referenceLayer = Main.getLayerManager().getEditLayer();
             if (referenceDataSet == null || referenceLayer == null) {
-                JOptionPane.showMessageDialog(Main.parent, tr("No valid OSM data layer present."), tr("Error freezing selection"), JOptionPane.ERROR_MESSAGE);
+                JOptionPane.showMessageDialog(Main.parent,
+                        tr("No valid OSM data layer present."), tr("Error freezing selection"),
+                        JOptionPane.ERROR_MESSAGE);
                 return;
             }
             referenceSelection.clear();
             referenceSelection.addAll(referenceDataSet.getSelected());
             if (referenceSelection.isEmpty()) {
-                JOptionPane.showMessageDialog(Main.parent, tr("Nothing is selected, please try again."), tr("Empty selection"), JOptionPane.ERROR_MESSAGE);
+                JOptionPane.showMessageDialog(Main.parent,
+                        tr("Nothing is selected, please try again."), tr("Empty selection"),
+                        JOptionPane.ERROR_MESSAGE);
                 return;
             }
             update();
@@ -331,6 +329,10 @@ public class SettingsDialog extends ExtendedDialog {
             subjectLayerLabel.setText(subjectLayer.getName());
             subjectSelectionLabel.setText(tr("{0}: {1} / {2}: {3} / {4}: {5}",
                     "Relations", numRelations, "Ways", numWays, "Nodes", numNodes));
+        } else {
+            subjectLayerLabel.setText("(none)");
+            subjectSelectionLabel.setText(tr("{0}: 0 / {1}: 0 / {2}: 0",
+                    "Relations", "Ways", "Nodes"));
         }
         numNodes = 0;
         numWays = 0;
@@ -348,8 +350,44 @@ public class SettingsDialog extends ExtendedDialog {
             referenceLayerLabel.setText(referenceLayer.getName());
             referenceSelectionLabel.setText(tr("{0}: {1} / {2}: {3} / {4}: {5}",
                     "Relations", numRelations, "Ways", numWays, "Nodes", numNodes));
+        } else {
+            referenceLayerLabel.setText("(none)");
+            referenceSelectionLabel.setText(tr("{0}: 0 / {1}: 0 / {2}: 0",
+                    "Relations", "Ways", "Nodes"));
         }
 
         //FIXME: properly update match finder settings
     }
+
+    /**
+     * To be called when a layer is removed.
+     * Clear any reference to the removed layer.
+     * @param e the layer remove event.
+     */
+    public void layerRemoving(LayerRemoveEvent e) {
+        Layer removedLayer = e.getRemovedLayer();
+        this.clear(removedLayer == referenceLayer, removedLayer == subjectLayer);
+    }
+
+    /**
+     * Clear some settings.
+     * @param shouldClearReference if "Reference" settings should be cleared.
+     * @param shouldClearSubject if "Subject" settings should be cleared.
+     */
+    public void clear(boolean shouldClearReference, boolean shouldClearSubject) {
+        if (shouldClearReference || shouldClearSubject) {
+            if (shouldClearReference) {
+                referenceLayer = null;
+                referenceDataSet = null;
+                referenceSelection.clear();
+            }
+            if (shouldClearSubject) {
+                subjectLayer = null;
+                subjectDataSet = null;
+                subjectSelection.clear();
+            }
+            update();
+        }
+    }
+
 }

--- a/src/org/openstreetmap/josm/plugins/conflation/SimpleMatch.java
+++ b/src/org/openstreetmap/josm/plugins/conflation/SimpleMatch.java
@@ -1,4 +1,5 @@
-// License: GPL. See LICENSE file for details. Copyright 2012 by Josh Doe and others.
+// License: GPL. For details, see LICENSE file.
+// Copyright 2012 by Josh Doe and others.
 package org.openstreetmap.josm.plugins.conflation;
 
 import org.openstreetmap.josm.data.osm.OsmPrimitive;

--- a/src/org/openstreetmap/josm/plugins/conflation/SimpleMatchList.java
+++ b/src/org/openstreetmap/josm/plugins/conflation/SimpleMatchList.java
@@ -1,7 +1,13 @@
-// License: GPL. See LICENSE file for details. Copyright 2012 by Josh Doe and others.
+// License: GPL. For details, see LICENSE file.
+// Copyright 2012 by Josh Doe and others.
 package org.openstreetmap.josm.plugins.conflation;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import org.openstreetmap.josm.data.osm.OsmPrimitive;
 
@@ -148,14 +154,22 @@ public class SimpleMatchList implements Iterable<SimpleMatch> {
     public void addConflationListChangedListener(SimpleMatchListListener listener) {
         listeners.addIfAbsent(listener);
     }
+    
+    public void removeConflationListChangedListener(SimpleMatchListListener listener) {
+        listeners.remove(listener);
+    }
+    
+    public void removeAllConflationListChangedListener() {
+        listeners.clear();
+    }
 
-    public void fireListChanged(){
+    public void fireListChanged() {
         for (SimpleMatchListListener l : listeners) {
             l.simpleMatchListChanged(this);
         }
     }
     
-    public void fireSelectionChanged(){
+    public void fireSelectionChanged() {
         for (SimpleMatchListListener l : listeners) {
             l.simpleMatchSelectionChanged(selected);
         }
@@ -167,7 +181,6 @@ public class SimpleMatchList implements Iterable<SimpleMatch> {
     
     /**
      * Set which {@see SimpleMatch} is currently selected. Set to null to clear selection.
-     * @param match 
      */
     public void setSelected(SimpleMatch match) {
         if (match != null)

--- a/src/org/openstreetmap/josm/plugins/conflation/SimpleMatchListListener.java
+++ b/src/org/openstreetmap/josm/plugins/conflation/SimpleMatchListListener.java
@@ -1,4 +1,5 @@
-// License: GPL. See LICENSE file for details. Copyright 2012 by Josh Doe and others.
+// License: GPL. For details, see LICENSE file.
+// Copyright 2012 by Josh Doe and others.
 package org.openstreetmap.josm.plugins.conflation;
 
 import java.util.Collection;
@@ -10,12 +11,12 @@ public interface SimpleMatchListListener {
      *
      * @param list The new list.
      */
-    public void simpleMatchListChanged(SimpleMatchList list);
+    void simpleMatchListChanged(SimpleMatchList list);
     
     /**
      * Informs the listener that the conflation list selection has changed.
      * 
      * @param selected The newly selected conflation match.
      */
-    public void simpleMatchSelectionChanged(Collection<SimpleMatch> selected);
+    void simpleMatchSelectionChanged(Collection<SimpleMatch> selected);
 }

--- a/src/org/openstreetmap/josm/plugins/conflation/SimpleMatchSettings.java
+++ b/src/org/openstreetmap/josm/plugins/conflation/SimpleMatchSettings.java
@@ -1,4 +1,5 @@
-// License: GPL. See LICENSE file for details. Copyright 2012 by Josh Doe and others.
+// License: GPL. For details, see LICENSE file.
+// Copyright 2012 by Josh Doe and others.
 package org.openstreetmap.josm.plugins.conflation;
 
 import com.vividsolutions.jcs.conflate.polygonmatch.FCMatchFinder;

--- a/src/org/openstreetmap/josm/plugins/conflation/SimpleMatchesTableModel.java
+++ b/src/org/openstreetmap/josm/plugins/conflation/SimpleMatchesTableModel.java
@@ -1,4 +1,5 @@
-// License: GPL. See LICENSE file for details. Copyright 2012 by Josh Doe and others.
+// License: GPL. For details, see LICENSE file.
+// Copyright 2012 by Josh Doe and others.
 package org.openstreetmap.josm.plugins.conflation;
 
 import java.util.Collection;
@@ -16,7 +17,7 @@ class SimpleMatchesTableModel extends AbstractTableModel implements SimpleMatchL
 
     private SimpleMatchList matches = null;
     // TODO: make columns dynamic
-    private final static String[] columnNames = {tr("Reference"), tr("Subject"), "Distance (m)", "Score", "Tags"};
+    private static final String[] columnNames = {tr("Reference"), tr("Subject"), "Distance (m)", "Score", "Tags"};
 
     @Override
     public int getColumnCount() {
@@ -70,7 +71,12 @@ class SimpleMatchesTableModel extends AbstractTableModel implements SimpleMatchL
 
     @Override
     public Class<?> getColumnClass(int c) {
-        return getValueAt(0, c).getClass();
+        Object value = getValueAt(0, c);
+        if (value != null) {
+            return value.getClass();
+        } else {
+            return Object.class;
+        }
     }
 
     /**
@@ -84,8 +90,16 @@ class SimpleMatchesTableModel extends AbstractTableModel implements SimpleMatchL
      * @param matches the matches to set
      */
     public void setMatches(SimpleMatchList matches) {
-        this.matches = matches;
-        fireTableDataChanged();
+        if (matches != this.matches) {
+            if (this.matches != null) {
+                this.matches.removeConflationListChangedListener(this);
+            }
+            this.matches = matches;
+            if (matches != null) {
+                matches.addConflationListChangedListener(this);
+            }
+            fireTableDataChanged();
+        }
     }
 
     @Override

--- a/src/org/openstreetmap/josm/plugins/conflation/UnmatchedObjectListModel.java
+++ b/src/org/openstreetmap/josm/plugins/conflation/UnmatchedObjectListModel.java
@@ -1,4 +1,5 @@
-// License: GPL. See LICENSE file for details. Copyright 2012 by Josh Doe and others.
+// License: GPL. For details, see LICENSE file.
+// Copyright 2012 by Josh Doe and others.
 package org.openstreetmap.josm.plugins.conflation;
 
 import java.util.Collection;

--- a/src/org/openstreetmap/josm/plugins/conflation/UserCancelRuntimeException.java
+++ b/src/org/openstreetmap/josm/plugins/conflation/UserCancelRuntimeException.java
@@ -1,0 +1,7 @@
+// License: GPL. For details, see LICENSE file.
+package org.openstreetmap.josm.plugins.conflation;
+
+/**
+ * Runtime Exception thrown when an operation is canceled by user.
+ */
+public class UserCancelRuntimeException extends RuntimeException {}


### PR DESCRIPTION
This correspond to a small update on the original this ticket I reported:
https://josm.openstreetmap.de/ticket/14408

I tried to update the conflation plugin, my modifications include:
* enabling checkstyle for Eclipse project
* listen to layer removal event to avoid referencing removed layers
* clear conflation data if plugin is hidden/shown again
* allow sorting of conflation match cases table (e.g. sorting by Score" or "Distance" column)
* listen to DataSet selection to select the corresponding match case if it exist.
* always recreate the toggle dialog in the ConflationPlugin.mapFrameInitialized.  I hope this will fix #13182 and #14136
* fix primitivesRemoved() event handler and rewrote ConflateMatchCommand, I hope this will fix #13066.

I have a doubt on the way I rewrote the class ConflateMatchCommand.

The undo/redo bug should have been fixed by this https://josm.openstreetmap.de/ticket/14410