### PR TITLE
[WIP] Improve performance when conflating large number of items by skipping GUI updates within the batch. Fix #14567

### DIFF
--- a/src/org/openstreetmap/josm/plugins/conflation/command/ConflateUnmatchedObjectCommand.java
+++ b/src/org/openstreetmap/josm/plugins/conflation/command/ConflateUnmatchedObjectCommand.java
@@ -52,16 +52,20 @@ public class ConflateUnmatchedObjectCommand extends Command {
 
     @Override
     public boolean executeCommand() {
+        listModel.beginUpdate();
         if (!addPrimitivesCommand.executeCommand())
             return false;
         listModel.removeAll(unmatchedObjects);
+        listModel.endUpdate();
         return true;
     }
 
     @Override
     public void undoCommand() {
+        listModel.beginUpdate();
         addPrimitivesCommand.undoCommand();
         listModel.addAll(unmatchedObjects);
+        listModel.endUpdate();
     }
 
     @Override

--- a/src/org/openstreetmap/josm/plugins/conflation/command/MoveMatchToUnmatchedCommand.java
+++ b/src/org/openstreetmap/josm/plugins/conflation/command/MoveMatchToUnmatchedCommand.java
@@ -27,19 +27,27 @@ public class MoveMatchToUnmatchedCommand extends RemoveMatchCommand {
     @Override
     public boolean executeCommand() {
         super.executeCommand();
+        referenceOnlyListModel.beginUpdate();
+        subjectOnlyListModel.beginUpdate();
         for (SimpleMatch match: toRemove) {
             referenceOnlyListModel.addElement(match.getReferenceObject());
             subjectOnlyListModel.addElement(match.getSubjectObject());
         }
+        referenceOnlyListModel.endUpdate();
+        subjectOnlyListModel.endUpdate();
         return true;
     }
 
     @Override
     public void undoCommand() {
+        referenceOnlyListModel.beginUpdate();
+        subjectOnlyListModel.beginUpdate();
         for (SimpleMatch match: toRemove) {
             referenceOnlyListModel.removeElement(match.getReferenceObject());
             subjectOnlyListModel.removeElement(match.getSubjectObject());
         }
+        referenceOnlyListModel.endUpdate();
+        subjectOnlyListModel.endUpdate();
         super.undoCommand();
     }
 

--- a/src/org/openstreetmap/josm/plugins/conflation/command/RemoveMatchCommand.java
+++ b/src/org/openstreetmap/josm/plugins/conflation/command/RemoveMatchCommand.java
@@ -24,22 +24,26 @@ import org.openstreetmap.josm.tools.ImageProvider;
 public class RemoveMatchCommand extends Command {
 
     protected final ArrayList<SimpleMatch> toRemove;
-    protected final SimpleMatchList matcheList;
+    protected final SimpleMatchList matchesList;
 
-    public RemoveMatchCommand(SimpleMatchList matcheList, Collection<SimpleMatch> toRemove) {
+    public RemoveMatchCommand(SimpleMatchList matchesList, Collection<SimpleMatch> toRemove) {
         this.toRemove = new ArrayList<>(toRemove);
-        this.matcheList = matcheList;
+        this.matchesList = matchesList;
     }
 
     @Override
     public boolean executeCommand() {
-        matcheList.removeAll(toRemove);
+        matchesList.beginUpdate();
+        matchesList.removeAll(toRemove);
+        matchesList.endUpdate();
         return true;
     }
 
     @Override
     public void undoCommand() {
-        matcheList.addAll(toRemove);
+        matchesList.beginUpdate();
+        matchesList.addAll(toRemove);
+        matchesList.endUpdate();
     }
 
     @Override

--- a/src/org/openstreetmap/josm/plugins/conflation/command/RemoveUnmatchedObjectCommand.java
+++ b/src/org/openstreetmap/josm/plugins/conflation/command/RemoveUnmatchedObjectCommand.java
@@ -26,12 +26,17 @@ public class RemoveUnmatchedObjectCommand extends Command {
 
     @Override
     public boolean executeCommand() {
-        return model.removeAll(objects);
+        model.beginUpdate();
+        boolean res = model.removeAll(objects);
+        model.endUpdate();
+        return res;
     }
 
     @Override
     public void undoCommand() {
+        model.beginUpdate();
         model.addAll(objects);
+        model.endUpdate();
     }
 
     @Override

--- a/src/org/openstreetmap/josm/plugins/conflation/command/StopOnErrorSequenceCommand.java
+++ b/src/org/openstreetmap/josm/plugins/conflation/command/StopOnErrorSequenceCommand.java
@@ -35,7 +35,7 @@ public class StopOnErrorSequenceCommand extends Command {
     public StopOnErrorSequenceCommand(String name, Collection<Command> sequenz) {
         this(name, sequenz.toArray(new Command[sequenz.size()]), sequenz.size());
     }
-    
+
     private StopOnErrorSequenceCommand(String name, Command[] sequence, int nbToExecute) {
         this.name = name;
         this.sequence = sequence;


### PR DESCRIPTION
I found that most of my performance issues were related to GNOME accessibility AtkWrapper: on table change, it was doing stuff that was freezing JOSM totally. I first commented out line `/etc/java-8-openjdk/accessibility.properties`:

```
# must comment this line below:
assistive_technologies=org.GNOME.Accessibility.AtkWrapper 
```

Starting from there, it was a bit better but still suboptimal because as we treat each row one by one, we fire JTable events for every row and so we update the GUI at each iteration. This PR basically removes all listeners when performing an action (via `UnlistenAction` base class) and reset them at the end of the batch process (+ manually triggers a fake `data changed` event). I can now conflate/delete items from the list at a much bigger speed (approx 1.3K conflations in 5sec).