### PR TITLE
Add a "keep subject value on conflict" parameter

### DIFF
--- a/src/org/openstreetmap/josm/plugins/conflation/SimpleMatch.java
+++ b/src/org/openstreetmap/josm/plugins/conflation/SimpleMatch.java
@@ -77,6 +77,8 @@ public class SimpleMatch implements Comparable<SimpleMatch> {
                     if (settings.overwriteTags.contains(refTag.getKey())) {
                         tagCollection.removeByKey(refTag.getKey());
                         tagCollection.add(refTag);
+                    } else if (settings.forceKeepTags.contains(refTag.getKey())) {
+                        // do nothing if we want to actually preserve the subject value
                     } else if (settings.mergeTags.contains(refTag.getKey()) || (referenceObject.getId() > 0)) {
                         tagCollection.add(refTag);
                     }

--- a/src/org/openstreetmap/josm/plugins/conflation/SimpleMatchSettings.java
+++ b/src/org/openstreetmap/josm/plugins/conflation/SimpleMatchSettings.java
@@ -44,6 +44,11 @@ public class SimpleMatchSettings {
      */
     public Collection<String> overwriteTags;
 
+    /**
+     * List of tags to keep without confirmation during conflation.
+     */
+    public Collection<String> forceKeepTags;
+
 
     /**
      * A Collection that always answer true when asked if it contains any object (except for the removed items!).

--- a/src/org/openstreetmap/josm/plugins/conflation/config/MergingPanel.java
+++ b/src/org/openstreetmap/josm/plugins/conflation/config/MergingPanel.java
@@ -27,7 +27,7 @@ import org.openstreetmap.josm.plugins.conflation.SimpleMatchSettings;
  * Panel to configure merging options (replace geometry, merge tags list).
  */
 public class MergingPanel extends JPanel {
-    
+
     private JCheckBox replaceGeometryCheckBox;
     private JCheckBox mergeTagsCheckBox;
     private JCheckBox mergeAllCheckBox;
@@ -36,42 +36,54 @@ public class MergingPanel extends JPanel {
     private JLabel mergeTagsExceptLabel;
     private JCheckBox overwriteTagsCheckbox; // may be null
     private DefaultPromptTextField overwriteTagsField; // may be null
+    private JLabel forceKeepTagsLabel; // may be null
+    private DefaultPromptTextField forceKeepTagsField; // may be null
     private AutoCompletionList referenceTagsAutoCompletionList;
 
     public MergingPanel(AutoCompletionList referenceKeysAutocompletionList, Preferences pref) {
         this.referenceTagsAutoCompletionList = referenceKeysAutocompletionList;
         this.initComponents();
     }
-    
+
     private void initComponents() {
         replaceGeometryCheckBox = new JCheckBox(tr("Replace Geometry"));
         mergeTagsCheckBox = new JCheckBox(tr("Merge Tags"));
         mergeAllCheckBox = new JCheckBox(tr("All"));
-        mergeTagsField = new DefaultPromptTextField(20, tr("List of tags to merge"));
+        mergeTagsField = new DefaultPromptTextField(20, tr("all"));
+        mergeTagsField.setToolTipText(tr("List of tags to merge"));
         mergeTagsField.setAutoCompletionList(referenceTagsAutoCompletionList);
         mergeTagsExceptLabel = new JLabel(tr("except"));
-        mergeTagsExceptField = new DefaultPromptTextField(20, tr("List of tags to NOT merge"));
+        mergeTagsExceptField = new DefaultPromptTextField(20, tr("none"));
+        mergeTagsExceptField.setToolTipText(tr("List of tags to NOT merge (they will be ignored)"));
         mergeTagsExceptField.setAutoCompletionList(referenceTagsAutoCompletionList);
         if (ExpertToggleAction.isExpert()) {
             overwriteTagsCheckbox = new JCheckBox(tr("Overwrite tags without confirmation"));
             overwriteTagsField = new DefaultPromptTextField(20, tr("none"));
-            overwriteTagsField.setToolTipText(tr("List of tags to overwrite without confirmation"));
+            overwriteTagsField.setToolTipText(tr("List of tags to overwrite on conflict using reference layer without confirmation"));
             overwriteTagsField.setAutoCompletionList(referenceTagsAutoCompletionList);
+            forceKeepTagsLabel = new JLabel(tr("and keep"));
+            forceKeepTagsField = new DefaultPromptTextField(20, tr("none"));
+            forceKeepTagsField.setToolTipText(tr("List of tags to keep on conflict from subject layer without confirmation"));
+            forceKeepTagsField.setAutoCompletionList(referenceTagsAutoCompletionList);
             overwriteTagsCheckbox.addActionListener(new ActionListener() {
                 @Override
                 public void actionPerformed(ActionEvent e) {
-                    overwriteTagsField.setEnabled(overwriteTagsCheckbox.isSelected());
+                    boolean enable = overwriteTagsCheckbox.isSelected();
+                    overwriteTagsField.setEnabled(enable);
+                    forceKeepTagsField.setEnabled(enable);
+                    forceKeepTagsLabel.setEnabled(enable);
                 }
             });
         }
         mergeTagsCheckBox.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent e) {
-                mergeAllCheckBox.setEnabled(mergeTagsCheckBox.isSelected());
-                mergeTagsField.setEnabled(mergeTagsCheckBox.isSelected());
-                mergeTagsExceptLabel.setEnabled(mergeTagsCheckBox.isSelected());
-                mergeTagsExceptField.setEnabled(mergeTagsCheckBox.isSelected());
-                if (mergeTagsCheckBox.isSelected()) {
+                boolean enable = mergeTagsCheckBox.isSelected();
+                mergeAllCheckBox.setEnabled(enable);
+                mergeTagsField.setEnabled(enable);
+                mergeTagsExceptLabel.setEnabled(enable);
+                mergeTagsExceptField.setEnabled(enable);
+                if (enable) {
                     mergeTagsField.setText("");
                     mergeTagsExceptField.setText("");
                     mergeAllCheckBox.setSelected(true);
@@ -138,16 +150,21 @@ public class MergingPanel extends JPanel {
         if (ExpertToggleAction.isExpert()) {
             horizonatGroup.addGroup(layout.createSequentialGroup()
                     .addComponent(overwriteTagsCheckbox)
-                    .addComponent(overwriteTagsField,
-                            GroupLayout.PREFERRED_SIZE, GroupLayout.DEFAULT_SIZE, GroupLayout.PREFERRED_SIZE)
+                    .addComponent(overwriteTagsField, GroupLayout.PREFERRED_SIZE, GroupLayout.DEFAULT_SIZE, GroupLayout.PREFERRED_SIZE)
+                    .addPreferredGap(LayoutStyle.ComponentPlacement.RELATED, 5, Short.MAX_VALUE)
+                    .addComponent(forceKeepTagsLabel)
+                    .addPreferredGap(LayoutStyle.ComponentPlacement.RELATED, 5, Short.MAX_VALUE)
+                    .addComponent(forceKeepTagsField, GroupLayout.PREFERRED_SIZE, GroupLayout.DEFAULT_SIZE, GroupLayout.PREFERRED_SIZE)
                     .addPreferredGap(LayoutStyle.ComponentPlacement.RELATED, 5, Short.MAX_VALUE));
             verticalGroup.addGroup(layout.createParallelGroup(GroupLayout.Alignment.BASELINE)
                     .addComponent(overwriteTagsCheckbox)
-                    .addComponent(overwriteTagsField));
+                    .addComponent(overwriteTagsField)
+                    .addComponent(forceKeepTagsLabel)
+                    .addComponent(forceKeepTagsField));
         }
         layout.setHorizontalGroup(horizonatGroup);
         layout.setVerticalGroup(verticalGroup);
-    }    
+    }
 
     public void savePreferences(Preferences pref) {
         pref.put(getClass().getName() + ".replaceGeometryCheckBox", replaceGeometryCheckBox.isSelected());
@@ -158,9 +175,10 @@ public class MergingPanel extends JPanel {
         if (overwriteTagsCheckbox != null) {
             pref.put(getClass().getName() + ".overwriteTagsCheckbox", overwriteTagsCheckbox.isSelected());
             pref.put(getClass().getName() + ".overwriteTagsField", overwriteTagsField.getText());
+            pref.put(getClass().getName() + ".forceKeepTagsField", forceKeepTagsField.getText());
         }
     }
-    
+
     public void restoreFromPreferences(Preferences pref) {
         replaceGeometryCheckBox.setSelected(pref.getBoolean(getClass().getName() + ".replaceGeometryCheckBox", true));
         mergeTagsField.setText(pref.get(getClass().getName() + ".mergeTagsField", ""));
@@ -169,10 +187,11 @@ public class MergingPanel extends JPanel {
         mergeTagsCheckBox.setSelected(pref.getBoolean(getClass().getName() + ".mergeTagsCheckBox", true));
         if (overwriteTagsCheckbox != null) {
             overwriteTagsField.setText(pref.get(getClass().getName() + ".overwriteTagsField", ""));
+            forceKeepTagsField.setText(pref.get(getClass().getName() + ".forceKeepTagsField", ""));
             overwriteTagsCheckbox.setSelected(pref.getBoolean(getClass().getName() + ".overwriteTagsCheckbox", false));
         }
     }
-    
+
     public void fillSettings(SimpleMatchSettings settings) {
         settings.isReplacingGeometry = replaceGeometryCheckBox.isSelected();
         if (mergeTagsCheckBox.isSelected()) {
@@ -189,10 +208,14 @@ public class MergingPanel extends JPanel {
         } else {
             settings.mergeTags = new ArrayList<>(0);
         }
-        if ((overwriteTagsField != null) && (overwriteTagsCheckbox != null) && overwriteTagsCheckbox.isSelected()) {
-            settings.overwriteTags = SimpleMatchFinderPanel.splitBySpaceComaOrSemicolon(overwriteTagsField.getText());
-        } else {
-            settings.overwriteTags = new ArrayList<>(0);
+
+        settings.overwriteTags = new ArrayList<>(0);
+        settings.forceKeepTags = new ArrayList<>(0);
+        if ((overwriteTagsCheckbox != null) && overwriteTagsCheckbox.isSelected()) {
+            if (overwriteTagsField != null)
+                settings.overwriteTags = SimpleMatchFinderPanel.splitBySpaceComaOrSemicolon(overwriteTagsField.getText());
+            if (forceKeepTagsField != null)
+                settings.forceKeepTags = SimpleMatchFinderPanel.splitBySpaceComaOrSemicolon(forceKeepTagsField.getText());
         }
     }
 }


### PR DESCRIPTION
This is actually the feature I wanted in the first place :-). It is basically useful when your reference set use generic tag (`building=yes` while your subject might be more precise `building=school`). In that case, always trusting the source set is (I think) useful/avoid many clicks.

Default:

![capture d ecran de 2017-04-03 00-51-01](https://cloud.githubusercontent.com/assets/1451988/24591686/aded4d46-1807-11e7-87dc-e434d86dc09d.png)

My workview:

![capture d ecran de 2017-04-03 00-51-43](https://cloud.githubusercontent.com/assets/1451988/24591691/c40f423c-1807-11e7-957e-2f40fc8d84d0.png)

By the way I am not sure if "overwrite tags" section should be for expert users only. I think any user might want this actually?