### PR TITLE
Change arrow direction from Reference -> Subject to Subject -> Reference

### DIFF
--- a/src/org/openstreetmap/josm/plugins/conflation/ConflationLayer.java
+++ b/src/org/openstreetmap/josm/plugins/conflation/ConflationLayer.java
@@ -66,8 +66,8 @@ public class ConflationLayer extends Layer {
             if (reference != null && subject != null) {
                 GeneralPath path = new GeneralPath();
                 // we have a pair, so draw line between them
-                Point p1 = mv.getPoint(ConflationUtils.getCenter(reference));
-                Point p2 = mv.getPoint(ConflationUtils.getCenter(subject));
+                Point p1 = mv.getPoint(ConflationUtils.getCenter(subject));
+                Point p2 = mv.getPoint(ConflationUtils.getCenter(reference));
                 path.moveTo(p1.x, p1.y);
                 path.lineTo(p2.x, p2.y);
                 //logger.info(String.format("Line %d,%d to %d,%d", p1.x, p1.y, p2.x, p2.y));


### PR DESCRIPTION
Please tell me if I am wrong, but as of today it looks to me that the arrow points in the wrong direction: instead of showing "this (subject) item will go THERE", it actually do the opposite "this (reference) item will come from this (subject) item"?
