### PR TITLE
build.xml: Add old version links

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -23,6 +23,8 @@
             <attribute name="12859_Plugin-Url" value="v0.5.6;https://github.com/JOSM/conflation/releases/download/v0.5.6/conflation.jar" />
             <attribute name="13561_Plugin-Url" value="v0.5.7;https://github.com/JOSM/conflation/releases/download/v0.5.7/conflation.jar" />
             <attribute name="13564_Plugin-Url" value="v0.6.0;https://github.com/JOSM/conflation/releases/download/v0.6.0/conflation.jar" />
+            <attribute name="14371_Plugin-Url" value="v0.6.5;https://github.com/JOSM/conflation/releases/download/v0.6.5/conflation.jar" />
+            <attribute name="16799_Plugin-Url" value="v0.6.6;https://github.com/JOSM/conflation/releases/download/v0.6.6/conflation.jar" />
         </manifest>
     </target>
 


### PR DESCRIPTION
From IRC:
> my JOSM only sees Conflation 0.6.0 in the plugin list for some reason
> apparently it is up to 0.6.7 now
> I am on the latest release version as well, 18193

It turns out we have been forgetting to update the old version links when we update the min version.

See also https://josm.openstreetmap.de/ticket/21403.