### PR TITLE
Remove false promise

### DIFF
--- a/src/org/openstreetmap/josm/plugins/conflation/config/SettingsDialog.java
+++ b/src/org/openstreetmap/josm/plugins/conflation/config/SettingsDialog.java
@@ -476,7 +476,7 @@ public class SettingsDialog extends ExtendedDialog {
         totalRelations += numRelations;
         if (totalRelations != 0) {
             JOptionPane.showMessageDialog(MainApplication.getMainFrame(),
-                    tr("Relations are not supported yet, please do not select them."), tr("Error"),
+                    tr("Relations are not supported."), tr("Error"),
                     JOptionPane.ERROR_MESSAGE);
         }
         updateFreezeButtons();


### PR DESCRIPTION
The "yet" was added 8 years ago, it's safe to say they will not be supported. And telling me to not select them is unnecessary, there's nothing wrong with selecting them they will just always show up under "Reference only" or "Subject only". 